### PR TITLE
format: Use lower-case initials for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 mkdeb
 mkdeb-*-amd64.deb
+
+.idea
+*.iml

--- a/deb/package.go
+++ b/deb/package.go
@@ -223,13 +223,13 @@ func NewPackageSpecFromFile(filename string) (*PackageSpec, error) {
 // Validate checks the syntax of various text fields in PackageSpec to verify
 // that they conform to the debian package specification. Errors from this call
 // should be passed to the user so they can fix errors in their config file.
-func (p *PackageSpec) Validate() error {
+func (p *PackageSpec) Validate(buildTime bool) error {
 	// Verify required fields are specified
 	missing := []string{}
 	if p.Package == "" {
 		missing = append(missing, "package")
 	}
-	if p.Version == "" {
+	if buildTime && p.Version == "" {
 		missing = append(missing, "version")
 	}
 	if p.Architecture == "" {

--- a/deb/package.go
+++ b/deb/package.go
@@ -150,33 +150,33 @@ var (
 // https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html
 type PackageSpec struct {
 	// Binary Debian Control File - Required fields
-	Package      string
+	Package      string `json:"package"`
 	Version      string `json:"-"`
-	Architecture string
-	Maintainer   string
-	Description  string
+	Architecture string `json:"architecture"`
+	Maintainer   string `json:"maintainer"`
+	Description  string `json:"description"`
 
 	// Optional Fields
-	Depends   []string
-	Conflicts []string `json:",omitempty"`
-	Breaks    []string `json:",omitempty"`
-	Replaces  []string `json:",omitempty"`
-	Section   string   // Defaults to "default"
-	Priority  string   // Defaults to "extra"
-	Homepage  string
+	Depends   []string `json:"depends"`
+	Conflicts []string `json:"conflicts,omitempty"`
+	Breaks    []string `json:"breaks,omitempty"`
+	Replaces  []string `json:"replaces,omitempty"`
+	Section   string   `json:"section"`  // Defaults to "default"
+	Priority  string   `json:"priority"` // Defaults to "extra"
+	Homepage  string   `json:"homepage"`
 
 	// Control Scripts
-	Preinst  string
-	Postinst string
-	Prerm    string
-	Postrm   string
+	Preinst  string `json:"preinst"`
+	Postinst string `json:"postinst"`
+	Prerm    string `json:"prerm"`
+	Postrm   string `json:"postrm"`
 
 	// Build time options
-	AutoPath         string // Defaults to "deb-pkg"
-	Files            map[string]string
-	TempPath         string `json:",omitempty"`
-	PreserveSymlinks bool   `json:",omitempty"`
-	UpgradeConfigs   bool   `json:",omitempty"`
+	AutoPath         string            `json:"autoPath"` // Defaults to "deb-pkg"
+	Files            map[string]string `json:"files"`
+	TempPath         string            `json:"tempPath,omitempty"`
+	PreserveSymlinks bool              `json:"preserveSymlinks,omitempty"`
+	UpgradeConfigs   bool              `json:"upgradeConfigs,omitempty"`
 
 	// Derived fields
 	InstalledSize int64 `json:"-"` // Kilobytes, rounded up. Derived from file sizes.

--- a/deb/package_test.go
+++ b/deb/package_test.go
@@ -40,12 +40,12 @@ func TestValidate(t *testing.T) {
 	p := PackageSpecFixture(t)
 	p.Version = "0.1.0"
 
-	if err := p.Validate(); err != nil {
+	if err := p.Validate(true); err != nil {
 		t.Fatal(err)
 	}
 
 	p2 := &PackageSpec{}
-	err := p2.Validate()
+	err := p2.Validate(true)
 	expected := "These required fields are missing: package, version, architecture, maintainer, description"
 	if err.Error() != expected {
 		t.Fatalf("-- Expected --\n%s\n-- Found --\n%s\n", expected, err.Error())

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func validate(config string) {
 	// Validate
 	p, err := deb.NewPackageSpecFromFile(filename)
 	handleError(err)
-	handleError(p.Validate())
+	handleError(p.Validate(false))
 }
 
 func build(config string, version string) {


### PR DESCRIPTION
This commit moves the configuration JSON file to use more conventional JSON
notation, with a lower-cased initial character. We stick to camel casing
however, so `AutoPath` becomes `autoPath`.