### PR TITLE
deb: Set control file permissions to 0644

### DIFF
--- a/deb/package.go
+++ b/deb/package.go
@@ -638,7 +638,7 @@ func (p *PackageSpec) CreateControlArchive(target string) error {
 	defer archive.Close()
 
 	header := tar.Header{
-		Mode:    0600,
+		Mode:    0644,
 		Uid:     0,
 		Gid:     0,
 		ModTime: time.Now(),


### PR DESCRIPTION
This commit fixes the lintian errors which result from the control file originally having permissions of 0600.

Prior to this change:

```
$ lintian package-made-with-mkdeb.deb
... output trimmed...
E: quickmkdeb: control-file-has-bad-permissions conffiles 0655 != 0644
E: quickmkdeb: control-file-has-bad-permissions md5sums 0655 != 0644
```

Packages built with this commit do not present these warnings.

Fixes #3.