### PR TITLE
WIP: Use temp dir + make archive task concurrent

### DIFF
--- a/deb/package_test.go
+++ b/deb/package_test.go
@@ -1,8 +1,10 @@
 package deb
 
 import (
+	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -235,4 +237,30 @@ func TestBuild(t *testing.T) {
 		t.Fatal(err)
 	}
 
+}
+
+func BenchmarkBuild(b *testing.B) {
+	p, err := NewPackageSpecFromFile(path.Join("test-fixtures", "example-basic.json"))
+	if err != nil {
+		b.Fatalf("Failed to load fixture: %s", err)
+	}
+	p.AutoPath = path.Join("test-fixtures", "package1")
+	p.Version = "0.1.0"
+	benchTmp, err := ioutil.TempDir("", "")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(benchTmp)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			tmpName, err := ioutil.TempFile(benchTmp, "output")
+			if err != nil {
+				b.Fatal(err)
+			}
+			err = p.Build(filepath.Join(benchTmp, tmpName.Name()))
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Tempdir bug fixed, builds can now run concurrently, benchmark added to verify.

Fixes #11

In my tests the performance improvements were about 12-15% for creating the
default mkdeb.json in a simple shell script loop:

for n in $(seq 1 100); do
  mkdeb build mkdeb.json
done

wo patch:
real 7,022s

with patch:

real 5.901s
15% increased throughput!

real 6.125s
12.8% increased throughput!

The real time is lower and there is no notable change in system resource usage.

I think this will benefit building speeds of smaller builds.